### PR TITLE
Handle pull request write failures

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -90,8 +90,12 @@ def main():  # pragma: no cover
 
             # Create a dependabot.yaml file, a branch, and a PR
             if not skip:
-                pull = commit_changes(title, body, repo, dependabot_file)
-                print("\tCreated pull request " + pull.html_url)
+                try:
+                    pull = commit_changes(title, body, repo, dependabot_file)
+                    print("\tCreated pull request " + pull.html_url)
+                except github3.exceptions.NotFoundError:
+                    print("\tFailed to create pull request. Check write permissions.")
+                    continue
 
     print("Done. " + str(count_eligible) + " repositories were eligible.")
 


### PR DESCRIPTION
# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->
fixes #19 

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

This pull request includes a change to the `main` function in the `evergreen.py` file. The change introduces error handling for the `commit_changes` function call. If a `NotFoundError` is raised by `github3`, a message is printed to the console indicating that the pull request creation failed due to insufficient write permissions.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
