### PR TITLE
Fix DRY_RUN always being true

### DIFF
--- a/env.py
+++ b/env.py
@@ -104,7 +104,7 @@ so that we can keep our dependencies up to date and secure."
     if dry_run:
         if dry_run not in ("true", "false"):
             raise ValueError("DRY_RUN environment variable not 'true' or 'false'")
-        dry_run_bool = True
+        dry_run_bool = dry_run == 'true'
     else:
         dry_run_bool = False
 

--- a/env.py
+++ b/env.py
@@ -104,7 +104,7 @@ so that we can keep our dependencies up to date and secure."
     if dry_run:
         if dry_run not in ("true", "false"):
             raise ValueError("DRY_RUN environment variable not 'true' or 'false'")
-        dry_run_bool = dry_run == 'true'
+        dry_run_bool = dry_run == "true"
     else:
         dry_run_bool = False
 

--- a/test_env.py
+++ b/test_env.py
@@ -122,7 +122,7 @@ we can keep our dependencies up to date and secure.",
         },
         clear=True,
     )
-    def test_get_env_vars_with_repos(self):
+    def test_get_env_vars_with_repos_no_dry_run(self):
         """Test that all environment variables are set correctly when DRY_RUN is false"""
         expected_result = (
             "my_organization",

--- a/test_env.py
+++ b/test_env.py
@@ -113,6 +113,34 @@ we can keep our dependencies up to date and secure.",
         with self.assertRaises(ValueError):
             get_env_vars()
 
+    @patch.dict(
+        os.environ,
+        {
+            "ORGANIZATION": "my_organization",
+            "GH_TOKEN": "my_token",
+            "DRY_RUN": "false",
+        },
+        clear=True,
+    )
+    def test_get_env_vars_with_repos(self):
+        """Test that all environment variables are set correctly when DRY_RUN is false"""
+        expected_result = (
+            "my_organization",
+            [],
+            "my_token",
+            "",
+            [],
+            "pull",
+            "Enable Dependabot",
+            "Dependabot could be enabled for this repository. \
+Please enable it by merging this pull request so that \
+we can keep our dependencies up to date and secure.",
+            None,
+            False,
+        )
+        result = get_env_vars()
+        self.assertEqual(result, expected_result)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request

Fix `DRY_RUN` always being `True`

## Proposed Changes

Fix `DRY_RUN` always being set to `True` regardless of whether the value is configured as `true` or `false`.

Fixes #27.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
