### PR TITLE
Use weekly cadence for workflow examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ name: Weekly dependabot checks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 1 * * 6'
+    - cron: '3 2 * * 6'
 
 permissions:
   issues: write
@@ -83,7 +83,7 @@ name: Weekly dependabot checks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '30 1 * * 6'
+    - cron: '3 2 * * 6'
 
 permissions:
   issues: write

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ name: Weekly dependabot checks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '3 2 1 * *'
+    - cron: '30 1 * * 6'
 
 permissions:
   issues: write
@@ -83,7 +83,7 @@ name: Weekly dependabot checks
 on:
   workflow_dispatch:
   schedule:
-    - cron: '3 2 1 * *'
+    - cron: '30 1 * * 6'
 
 permissions:
   issues: write


### PR DESCRIPTION
# Pull Request

Updates the basic and advanced workflow examples to use a weekly `schedule` cadence, rather than monthly.

Fixes https://github.com/github/evergreen/issues/51.
 
## Proposed Changes

With this change, the example cron workflow will run [weekly on Saturdays](https://crontab.guru/#3_2_*_*_6).

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
