### PR TITLE
Add flag to disable Dependabot security updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Below are the allowed configuration options:
 | `PROJECT_ID`          | False    | ""     | If set, this will assign the issue or pull request to the project with the given ID. ( The project ID on GitHub can be located by navigating to the respective project and observing the URL's end.) **The `ORGANIZATION` variable is required** |
 | `DRY_RUN`             | False    | false   | If set to true, this action will not create any issues or pull requests. It will only log the repositories that could have dependabot enabled. This is useful for testing. |
 | `GROUP_DEPENDENCIES`             | False    | false   | If set to true, dependabot configuration will group dependencies updates based on [dependency type](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups) (production or development, where supported) |
+| `ENABLE_SECURITY_UPDATES`             | False    | true   | If set to true, Evergreen will enable [Dependabot security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates) on target repositories. Note that the Github token need to have the `administration:right` permission on every repository in scope to successfully enable security updates.  |
 
 ### Example workflows
 

--- a/env.py
+++ b/env.py
@@ -23,6 +23,7 @@ def get_env_vars() -> (
         str,
         str | None,
         bool | None,
+        bool | None,
     ]
 ):
     """
@@ -44,6 +45,7 @@ def get_env_vars() -> (
         dry_run (bool): Whether or not to actually open issues/pull requests
         commit_message (str): The commit message of the follow up
         group_dependencies (bool): Whether to group dependencies in the dependabot.yml file
+        enable_security_updates (bool): Whether to enable security updates in target repositories
     """
     # Load from .env file if it exists
     dotenv_path = join(dirname(__file__), ".env")
@@ -141,6 +143,20 @@ Please enable it by merging this pull request so that we can keep our dependenci
     else:
         group_dependencies_bool = False
 
+    # enable_security_updates is optional but true by default to maintain backward compatibility
+    enable_security_updates = os.getenv("ENABLE_SECURITY_UPDATES")
+    enable_security_updates = (
+        enable_security_updates.lower() if enable_security_updates else "true"
+    )
+    if enable_security_updates:
+        if enable_security_updates not in ("true", "false"):
+            raise ValueError(
+                "ENABLE_SECURITY_UPDATES environment variable not 'true' or 'false'"
+            )
+        enable_security_updates_bool = enable_security_updates == "true"
+    else:
+        enable_security_updates_bool = False
+
     dry_run = os.getenv("DRY_RUN")
     dry_run = dry_run.lower() if dry_run else None
     if dry_run:
@@ -167,4 +183,5 @@ Please enable it by merging this pull request so that we can keep our dependenci
         commit_message,
         project_id,
         group_dependencies_bool,
+        enable_security_updates_bool,
     )

--- a/evergreen.py
+++ b/evergreen.py
@@ -28,6 +28,7 @@ def main():  # pragma: no cover
         commit_message,
         project_id,
         group_dependencies,
+        enable_security_updates,
     ) = env.get_env_vars()
 
     # Auth to GitHub.com or GHE
@@ -94,8 +95,10 @@ def main():  # pragma: no cover
             continue
 
         # Get dependabot security updates enabled if possible
-        if not is_dependabot_security_updates_enabled(repo.owner, repo.name, token):
-            enable_dependabot_security_updates(repo.owner, repo.name, token)
+        if enable_security_updates:
+            if not is_dependabot_security_updates_enabled(repo.owner, repo.name, token):
+                enable_dependabot_security_updates(repo.owner, repo.name, token)
+
         if follow_up_type == "issue":
             skip = check_pending_issues_for_duplicates(title, repo)
             if not skip:

--- a/test_env.py
+++ b/test_env.py
@@ -40,6 +40,7 @@ class TestEnv(unittest.TestCase):
             "Create dependabot configuration",
             "123",
             False,
+            True,  # enable_security_updates
         )
         result = get_env_vars()
         self.assertEqual(result, expected_result)
@@ -77,6 +78,7 @@ class TestEnv(unittest.TestCase):
             "Create dependabot configuration",
             "123",
             False,
+            True,  # enable_security_updates
         )
         result = get_env_vars()
         self.assertEqual(result, expected_result)
@@ -106,6 +108,7 @@ we can keep our dependencies up to date and secure.",
             "Create dependabot.yaml",
             None,
             False,
+            True,  # enable_security_updates
         )
         result = get_env_vars()
         self.assertEqual(result, expected_result)
@@ -155,6 +158,39 @@ we can keep our dependencies up to date and secure.",
             "Create dependabot.yaml",
             None,
             False,
+            True,  # enable_security_updates
+        )
+        result = get_env_vars()
+        self.assertEqual(result, expected_result)
+
+    @patch.dict(
+        os.environ,
+        {
+            "ORGANIZATION": "my_organization",
+            "GH_TOKEN": "my_token",
+            "ENABLE_SECURITY_UPDATES": "false",
+        },
+        clear=True,
+    )
+    def test_get_env_vars_with_repos_disabled_security_updates(self):
+        """Test that all environment variables are set correctly when DRY_RUN is false"""
+        expected_result = (
+            "my_organization",
+            [],
+            "my_token",
+            "",
+            [],
+            "pull",
+            "Enable Dependabot",
+            "Dependabot could be enabled for this repository. \
+Please enable it by merging this pull request so that \
+we can keep our dependencies up to date and secure.",
+            None,
+            False,
+            "Create dependabot.yaml",
+            None,
+            False,
+            False,  # enable_security_updates
         )
         result = get_env_vars()
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
# Pull Request
Add flag to disable Dependabot security updates

## Proposed Changes
To enable Dependabot security updates the api requires `administration:write` on all target repositories. For organization owners this might be an excessive scope to grant. See https://github.com/github/evergreen/issues/25#issuecomment-1963726972 

This patch makes this feature enabled by default (to maintain backward compatibility), but optional so that can be easily disabled with:
```
ENABLE_SECURITY_UPDATES = false
```

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
