### PR TITLE
Fixed failed check for duplicate pull request

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -190,7 +190,7 @@ def check_pending_pulls_for_duplicates(title, repo) -> bool:
     pull_requests = repo.pull_requests(state="open")
     skip = False
     for pull_request in pull_requests:
-        if pull_request.head.ref.startswith(title):
+        if pull_request.title.startswith(title):
             print("\tPull request already exists: " + pull_request.html_url)
             skip = True
             break

--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -237,7 +237,7 @@ class TestCheckPendingPullsForDuplicates(unittest.TestCase):
         """Test the check_pending_pulls_for_duplicates function where there are no duplicates to be found."""
         mock_repo = MagicMock()  # Mock repo object
         mock_pull_request = MagicMock()
-        mock_pull_request.head.ref = "not-dependabot-branch"
+        mock_pull_request.title = "not-dependabot-branch"
         mock_repo.pull_requests.return_value = [mock_pull_request]
 
         result = check_pending_pulls_for_duplicates("dependabot-branch", mock_repo)
@@ -249,12 +249,10 @@ class TestCheckPendingPullsForDuplicates(unittest.TestCase):
         """Test the check_pending_pulls_for_duplicates function where there are duplicates to be found."""
         mock_repo = MagicMock()  # Mock repo object
         mock_pull_request = MagicMock()
-        mock_pull_request.head.ref = "dependabot-branch"
+        mock_pull_request.title = "dependabot-branch"
         mock_repo.pull_requests.return_value = [mock_pull_request]
 
-        result = check_pending_pulls_for_duplicates(
-            mock_pull_request.head.ref, mock_repo
-        )
+        result = check_pending_pulls_for_duplicates(mock_pull_request.title, mock_repo)
 
         # Assert that the function returned the expected result
         self.assertEqual(result, True)


### PR DESCRIPTION
# Pull Request
Fixed failed check for duplicate pull request

## Proposed Changes
Fixes #57 
The check for duplicate PRs was comparing the title of the pull request to be against all current open pull request head ref's instead of their title.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [ ] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
