### PR TITLE
fix: referring to mix package key as hex.

### DIFF
--- a/dependabot_file.py
+++ b/dependabot_file.py
@@ -234,7 +234,7 @@ updates:
         ):
             compatible_package_manager_found = True
             hex_found = True
-            dependabot_file += make_dependabot_config("hex", group_dependencies)
+            dependabot_file += make_dependabot_config("mix", group_dependencies)
     except github3.exceptions.NotFoundError:
         pass
     try:
@@ -245,7 +245,7 @@ updates:
         ):
             compatible_package_manager_found = True
             hex_found = True
-            dependabot_file += make_dependabot_config("hex", group_dependencies)
+            dependabot_file += make_dependabot_config("mix", group_dependencies)
     except github3.exceptions.NotFoundError:
         pass
 

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -153,7 +153,7 @@ updates:
             expected_result = """---
 version: 2
 updates:
-  - package-ecosystem: 'hex'
+  - package-ecosystem: 'mix'
     directory: '/'
     schedule:
         interval: 'weekly'


### PR DESCRIPTION
fixes #70

# Pull Request
<!-- PR title should be brief and descriptive for a good changelog entry -->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
This pull request includes changes to the `dependabot_file.py` and `test_dependabot_file.py` files, specifically in the `build_dependabot_file` function and the `test_build_dependabot_file_with_hex` test case. The changes are focused on replacing the package ecosystem from 'hex' to 'mix'.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `bug`, `documentation`, `enhancement`, `infrastructure`, or `breaking`
