### PR TITLE
fix: yaml hierarchy indicates 2 spaces instead of 4

### DIFF
--- a/dependabot_file.py
+++ b/dependabot_file.py
@@ -17,14 +17,14 @@ def make_dependabot_config(ecosystem, group_dependencies) -> str:
     dependabot_config = f"""  - package-ecosystem: '{ecosystem}'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
     if group_dependencies:
         dependabot_config += """    groups:
-        production-dependencies:
-            dependency-type: 'production'
-        development-dependencies:
-            dependency-type: 'development'
+      production-dependencies:
+        dependency-type: 'production'
+      development-dependencies:
+        dependency-type: 'development'
 """
     return dependabot_config
 

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -35,7 +35,7 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -53,7 +53,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -77,7 +77,7 @@ updates:
   - package-ecosystem: 'pip'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -98,7 +98,7 @@ updates:
   - package-ecosystem: 'cargo'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -114,7 +114,7 @@ updates:
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
         result = build_dependabot_file(repo, False, [])
         self.assertEqual(result, expected_result)
@@ -135,7 +135,7 @@ updates:
   - package-ecosystem: 'composer'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -156,7 +156,7 @@ updates:
   - package-ecosystem: 'mix'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
             result = build_dependabot_file(repo, False, [])
             self.assertEqual(result, expected_result)
@@ -172,7 +172,7 @@ updates:
   - package-ecosystem: 'nuget'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
         result = build_dependabot_file(repo, False, [])
         self.assertEqual(result, expected_result)
@@ -188,7 +188,7 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
 """
         result = build_dependabot_file(repo, False, [])
         self.assertEqual(result, expected_result)
@@ -204,12 +204,12 @@ updates:
   - package-ecosystem: 'docker'
     directory: '/'
     schedule:
-        interval: 'weekly'
+      interval: 'weekly'
     groups:
-        production-dependencies:
-            dependency-type: 'production'
-        development-dependencies:
-            dependency-type: 'development'
+      production-dependencies:
+        dependency-type: 'production'
+      development-dependencies:
+        dependency-type: 'development'
 """
         result = build_dependabot_file(repo, True, [])
         self.assertEqual(result, expected_result)


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Fix spacing on dependabot.yaml output

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
