### PR TITLE
ci: Add test for Terraform dependabot config

### DIFF
--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -251,7 +251,7 @@ updates:
         result = build_dependabot_file(repo, False, [], None)
         self.assertEqual(result, expected_result)
 
-    def test_build_dependabot_file_with_terraform(self):
+    def test_build_dependabot_file_with_terraform_with_files(self):
         """Test that the dependabot.yml file is built correctly with Terraform"""
         repo = MagicMock()
         response = MagicMock()
@@ -271,6 +271,13 @@ updates:
 """
         result = build_dependabot_file(repo, False, [], None)
         self.assertEqual(result, expected_result)
+
+    def test_build_dependabot_file_with_terraform_without_files(self):
+        """Test that the dependabot.yml file is built correctly with Terraform"""
+        repo = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        repo.file_contents.side_effect = github3.exceptions.NotFoundError(resp=response)
 
         # Test absence of Terraform files
         repo.directory_contents.side_effect = lambda path: [] if path == "/" else []


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
fixes #152

This pull request introduces a new test case to ensure the correct generation of dependabot configuration files for Terraform projects within the `test_dependabot_file.py` file. 

- **Adds a new test case**: Implements `test_build_dependabot_file_with_terraform` to verify that dependabot configuration files correctly include Terraform as a package ecosystem when Terraform files are present in the repository.
- **Handles absence of Terraform files and no files at all**: Enhances the test to also verify that no Terraform entry is added to the dependabot configuration file when no Terraform files are present in the repository.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
