### PR TITLE
ci: Add test for GitHub Actions dependabot configuration

### DIFF
--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -293,6 +293,40 @@ updates:
         result = build_dependabot_file(repo, False, [], None)
         self.assertIsNone(result)
 
+    def test_build_dependabot_file_with_github_actions(self):
+        """Test that the dependabot.yml file is built correctly with GitHub Actions"""
+        repo = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        repo.file_contents.side_effect = github3.exceptions.NotFoundError(resp=response)
+        repo.directory_contents.side_effect = lambda path: (
+            [("test.yml", None)] if path == ".github/workflows" else []
+        )
+
+        expected_result = """---
+version: 2
+updates:
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+"""
+        result = build_dependabot_file(repo, False, [], None)
+        self.assertEqual(result, expected_result)
+
+    def test_build_dependabot_file_with_github_actions_without_files(self):
+        """Test that the dependabot.yml file is None when no YAML files are found in the .github/workflows/ directory."""
+        repo = MagicMock()
+        response = MagicMock()
+        response.status_code = 404
+        repo.file_contents.side_effect = github3.exceptions.NotFoundError(resp=response)
+        repo.directory_contents.side_effect = github3.exceptions.NotFoundError(
+            resp=response
+        )
+
+        result = build_dependabot_file(repo, False, [], None)
+        self.assertEqual(result, None)
+
     def test_build_dependabot_file_with_groups(self):
         """Test that the dependabot.yml file is built correctly with grouped dependencies"""
         repo = MagicMock()


### PR DESCRIPTION
# Pull Request
<!-- 
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Fixes #156

This pull request introduces tests for the GitHub Actions dependabot configuration in the `test_dependabot_file.py` file, enhancing the test coverage for dependabot configurations.

- **Adds new tests**: Implements two new test methods, `test_build_dependabot_file_with_github_actions` and `test_build_dependabot_file_with_github_actions_without_files`.
  - The first test ensures that the dependabot configuration for GitHub Actions is correctly generated when YAML files are present in the `.github/workflows` directory.
  - The second test verifies that the dependabot configuration is `None` when no YAML files are found in the `.github/workflows` directory, aligning with the expected behavior for repositories without GitHub Actions workflows.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
