### PR TITLE
fix: Add a default value for dependabot_filename_to_use

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -80,8 +80,8 @@ def main():  # pragma: no cover
             print("Skipping " + repo.full_name + " (visibility-filtered)")
             continue
         existing_config = None
-        filename_list = [".github/dependabot.yml", ".github/dependabot.yaml"]
-        dependabot_filename_to_use = None
+        filename_list = [".github/dependabot.yaml", ".github/dependabot.yml"]
+        dependabot_filename_to_use = filename_list[0]  # Default to the first filename
         for filename in filename_list:
             existing_config = check_existing_config(repo, filename, update_existing)
             if existing_config:


### PR DESCRIPTION
# Pull Request
Fix https://github.com/github/evergreen/issues/168

## Proposed Changes
Set a default value to dependabot_filename_to_use rather than `None`

## Readiness Checklist
### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
