### PR TITLE
fix: update_existing logic

### DIFF
--- a/test_evergreen.py
+++ b/test_evergreen.py
@@ -662,7 +662,7 @@ class TestCheckExistingConfig(unittest.TestCase):
         filename = "dependabot.yaml"
         mock_repo.file_contents.return_value.size = 5
 
-        result = check_existing_config(mock_repo, filename, True)
+        result = check_existing_config(mock_repo, filename)
 
         self.assertIsNotNone(result)
 
@@ -676,21 +676,7 @@ class TestCheckExistingConfig(unittest.TestCase):
             mock_response
         )
 
-        result = check_existing_config(mock_repo, "dependabot.yml", True)
-
-        self.assertIsNone(result)
-
-    def test_check_existing_config_with_existing_config_without_update_existing_set(
-        self,
-    ):
-        """
-        Test the case where there is an existing configuration but UPDATE_EXISTING is False
-        """
-        mock_repo = MagicMock()
-        filename = "dependabot.yaml"
-        mock_repo.file_contents.return_value.size = 5
-
-        result = check_existing_config(mock_repo, filename, False)
+        result = check_existing_config(mock_repo, "dependabot.yml")
 
         self.assertIsNone(result)
 


### PR DESCRIPTION
# Pull Request
fixes #208 
<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
Simplify and correct the handling of the `update_existing` parameter when checking for existing Dependabot configuration files. The most important changes include removing the `update_existing` parameter from the `check_existing_config` function and updating the surrounding logic accordingly. This should result in fixing the situation described in #208. I did have to remove a test now that the `update_existing` parameter is no longer used in the `check_existing_config` function.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
