### PR TITLE
fix: Ensure exemption list of ecosystem is not overwritten

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -107,7 +107,7 @@ def main():  # pragma: no cover
         dependabot_file = build_dependabot_file(
             repo,
             group_dependencies,
-            exempt_ecosystems,
+            exempt_ecosystems.copy(),
             repo_specific_exemptions,
             existing_config,
         )

--- a/evergreen.py
+++ b/evergreen.py
@@ -107,7 +107,7 @@ def main():  # pragma: no cover
         dependabot_file = build_dependabot_file(
             repo,
             group_dependencies,
-            exempt_ecosystems.copy(),
+            exempt_ecosystems,
             repo_specific_exemptions,
             existing_config,
         )

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -392,19 +392,25 @@ updates:
         Test the case where there are multiple repos with few existing dependabot config
         """
         existing_config_repo = MagicMock()
-        existing_config_repo.file_contents.side_effect = lambda f, filename="Gemfile": f == filename
+        existing_config_repo.file_contents.side_effect = (
+            lambda f, filename="Gemfile": f == filename
+        )
 
         existing_config = MagicMock()
         existing_config.decoded = b'---\nversion: 2\nupdates:\n  - package-ecosystem: "bundler"\n\
     directory: "/"\n    schedule:\n      interval: "weekly"\n    commit-message:\n      prefix: "chore(deps)"\n'
         exempt_ecosystems = []
-        result = build_dependabot_file(existing_config_repo, False, exempt_ecosystems, {}, existing_config)
+        result = build_dependabot_file(
+            existing_config_repo, False, exempt_ecosystems, {}, existing_config
+        )
         self.assertEqual(result, None)
 
         no_existing_config_repo = MagicMock()
         filename_list = ["package.json", "package-lock.json", "yarn.lock"]
         for filename in filename_list:
-            no_existing_config_repo.file_contents.side_effect = lambda f, filename=filename: f == filename
+            no_existing_config_repo.file_contents.side_effect = (
+                lambda f, filename=filename: f == filename
+            )
             expected_result = """---
 version: 2
 updates:
@@ -413,7 +419,9 @@ updates:
     schedule:
       interval: 'weekly'
 """
-        result = build_dependabot_file(no_existing_config_repo, False, exempt_ecosystems, {}, None)
+        result = build_dependabot_file(
+            no_existing_config_repo, False, exempt_ecosystems, {}, None
+        )
         self.assertEqual(result, expected_result)
 
     def test_check_multiple_repos_with_no_dependabot_config(self):
@@ -438,7 +446,9 @@ updates:
         no_existing_config_repo = MagicMock()
         filename_list = ["package.json", "package-lock.json", "yarn.lock"]
         for filename in filename_list:
-            no_existing_config_repo.file_contents.side_effect = lambda f, filename=filename: f == filename
+            no_existing_config_repo.file_contents.side_effect = (
+                lambda f, filename=filename: f == filename
+            )
             expected_result = """---
 version: 2
 updates:
@@ -447,7 +457,9 @@ updates:
     schedule:
       interval: 'weekly'
 """
-        result = build_dependabot_file(no_existing_config_repo, False, exempt_ecosystems, {}, None)
+        result = build_dependabot_file(
+            no_existing_config_repo, False, exempt_ecosystems, {}, None
+        )
         self.assertEqual(result, expected_result)
 
 

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -450,5 +450,6 @@ updates:
         result = build_dependabot_file(no_existing_config_repo, False, exempt_ecosystems, {}, None)
         self.assertEqual(result, expected_result)
 
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Pull Request

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

Currently we pass in the env variable directly when building a dependabot config file. When iterating through multiple repos, there is a possibility that if one of the previous repos has an existing dependabot config, we land up adding those to the exemption list in order to not add that config again to the dependabot.yml file. We land up using the same exempt_ecosystem for all the foll. repos resulting in skipping of creating that dependabot.yml.

This fix always passes in a copy of the original `exempt_ecosystems` environment variable ensuring the original data is not over written.

```
Checking hello-gh-actions for compatible package managers
before adding exempt_ecosystems:  []
existing_config:  <Contents [.github/dependabot.yaml]>
 exempt_ecosystems:  ['gomod', 'docker', 'github-actions']
repo: hello-gh-actions manager: bundler
repo: hello-gh-actions manager: npm
repo: hello-gh-actions manager: pip
repo: hello-gh-actions manager: cargo
repo: hello-gh-actions manager: gomod
repo: hello-gh-actions manager: composer
repo: hello-gh-actions manager: mix
repo: hello-gh-actions manager: nuget
repo: hello-gh-actions manager: docker
	No (new) compatible package manager found
Checking test for compatible package managers
before adding exempt_ecosystems:  ['gomod', 'docker', 'github-actions']
existing_config:  None
 exempt_ecosystems:  ['gomod', 'docker', 'github-actions']
repo: test manager: bundler
repo: test manager: npm
repo: test manager: pip
repo: test manager: cargo
repo: test manager: gomod
repo: test manager: composer
repo: test manager: mix
repo: test manager: nuget
repo: test manager: docker
	No (new) compatible package manager found
```
In the example above, the first repo `hello-gh-actions` already has a dependabot.yml file with gomod, docker & github-actions package manager. The `test` repo on the other hand does not have any `dependabot.yml` file and the expectation is for evergreen to create a pull request but as you see from the example it assumes the same ecosystems are added to the exempt list and skips adding the pull request.

Below is my evergreen.yml config:
```
 - name: Run evergreen action
    uses: github/evergreen@ff2f3ffd6bf88d33354f49a79ecbffd1d0cf98c9 #v1.12.0
    env:
      GH_TOKEN: ${{ secrets.GH_TOKEN }}
      ORGANIZATION: <orgid>
      TITLE: "Add dependabot configuration"
      TYPE: pull
      BATCH_SIZE: 10
      ENABLE_SECURITY_UPDATES: true
      UPDATE_EXISTING: true
```

## Readiness Checklist

### Author/Contributor

- [ ] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
