### PR TITLE
fix: ensure existing dependabot configs without end of file newlines get processed properly

### DIFF
--- a/dependabot_file.py
+++ b/dependabot_file.py
@@ -139,6 +139,10 @@ updates:
             try:
                 if repo.file_contents(file):
                     package_managers_found[manager] = True
+                    # If the last thing in the file is not a newline,
+                    # add one before adding a new language config to the file
+                    if dependabot_file and dependabot_file[-1] != "\n":
+                        dependabot_file += "\n"
                     dependabot_file += make_dependabot_config(
                         manager, group_dependencies, indent, schedule, schedule_day
                     )

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -108,6 +108,36 @@ updates:
         )
         self.assertEqual(result, expected_result)
 
+    def test_build_dependabot_file_with_2_space_indent_existing_config_bundler_with_update_and_no_newline(
+        self,
+    ):
+        """Test that the dependabot.yml file is built correctly with bundler"""
+        repo = MagicMock()
+        repo.file_contents.side_effect = lambda f, filename="Gemfile": f == filename
+
+        # expected_result maintains existing ecosystem with custom configuration
+        # and adds new ecosystem
+        expected_result = """---
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "chore(deps)"
+  - package-ecosystem: 'bundler'
+    directory: '/'
+    schedule:
+      interval: 'weekly'"""
+        existing_config = MagicMock()
+        existing_config.decoded = b'---\nversion: 2\nupdates:\n  - package-ecosystem: "pip"\n    directory: "/"\n\
+    schedule:\n      interval: "weekly"\n    commit-message:\n      prefix: "chore(deps)"\n'
+        result = build_dependabot_file(
+            repo, False, [], {}, existing_config, "weekly", ""
+        )
+        self.assertEqual(result, expected_result)
+
     def test_build_dependabot_file_with_weird_space_indent_existing_config_bundler_with_update(
         self,
     ):

--- a/test_dependabot_file.py
+++ b/test_dependabot_file.py
@@ -129,10 +129,11 @@ updates:
   - package-ecosystem: 'bundler'
     directory: '/'
     schedule:
-      interval: 'weekly'"""
+      interval: 'weekly'
+"""
         existing_config = MagicMock()
         existing_config.decoded = b'---\nversion: 2\nupdates:\n  - package-ecosystem: "pip"\n    directory: "/"\n\
-    schedule:\n      interval: "weekly"\n    commit-message:\n      prefix: "chore(deps)"\n'
+    schedule:\n      interval: "weekly"\n    commit-message:\n      prefix: "chore(deps)"'
         result = build_dependabot_file(
             repo, False, [], {}, existing_config, "weekly", ""
         )


### PR DESCRIPTION
# Pull Request
fixes https://github.com/github/evergreen/issues/231

Ensure existing dependabot configs without end of file newlines get processed properly so we can add new language configs without a formatting error. See #231 for details on formatting error.
<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes

<!-- Describe what the changes are and link to a GitHub Issue if one exists -->
This pull request introduces a new test case to the `test_dependabot_file.py` file to ensure the `dependabot.yml` file is built correctly with bundler and specific configurations. It also modifies the existing config builder code to detect existing newlines and handle the case where one doesn't already exist. The goal of all of this is to prevent writing new language configs starting on the same line as the previous config, breaking the yaml format.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
