### PR TITLE
docs: add ossf badge with link to project details

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Lint Code Base](https://github.com/github/evergreen/actions/workflows/super-linter.yaml/badge.svg)](https://github.com/github/evergreen/actions/workflows/super-linter.yaml)
 [![Python package](https://github.com/github/evergreen/actions/workflows/python-ci.yml/badge.svg)](https://github.com/github/evergreen/actions/workflows/python-ci.yml)
 [![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/github/evergreen/badge)](https://scorecard.dev/viewer/?uri=github.com/github/evergreen)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/9523/badge)](https://www.bestpractices.dev/projects/9523)
 
 This is a GitHub Action that given an organization or specified repositories, opens an issue/PR if dependabot is not enabled, or there are more package ecosystems that could be. It also enables [automated security updates](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#managing-dependabot-security-updates-for-your-repositories) for the repository.
 


### PR DESCRIPTION
# Pull Request
Adding a badge to help improve our ossf scorecard score

<!--
PR title needs to be prefixed with a conventional commit type
(build,chore,ci,docs,feat,fix,perf,refactor,revert,style,test)

It should also be brief and descriptive for a good changelog entry

examples: "feat: add new logger" or "fix: remove unused imports"
-->

## Proposed Changes
add the badge
<!-- Describe what the changes are and link to a GitHub Issue if one exists -->

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [x] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [x] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
