### PR TITLE
chore: Pin and upgrade all immutable-eligible actions to their semantic versions

### DIFF
--- a/.github/workflows/docker-ci.yml
+++ b/.github/workflows/docker-ci.yml
@@ -14,6 +14,6 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@4.2.2
+      - uses: actions/checkout@v4.2.2
       - name: Build the Docker image
         run: docker build . --file Dockerfile --platform linux/amd64

--- a/.github/workflows/major-version-updater.yml
+++ b/.github/workflows/major-version-updater.yml
@@ -15,7 +15,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout Repo
-        uses: actions/checkout@4.2.2
+        uses: actions/checkout@v4.2.2
 
       - name: version
         id: version

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@5.3.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: actions/checkout@4.2.2
+      - uses: actions/checkout@v4.2.2
       - name: Push Docker Image
         if: ${{ success() }}
         uses: docker/build-push-action@4f58ea79222b3b9dc2c8bbdd6debcef730109a75

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -36,7 +36,7 @@ jobs:
           results_format: sarif
           publish_results: true
       - name: "Upload artifact"
-        uses: actions/upload-artifact@4.4.3
+        uses: actions/upload-artifact@v4.4.3
         with:
           name: SARIF file
           path: results.sarif

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -13,7 +13,7 @@ jobs:
       issues: write
       pull-requests: read
     steps:
-      - uses: actions/stale@9.0.0
+      - uses: actions/stale@v9.0.0
         with:
           stale-issue-message: "This issue is stale because it has been open 21 days with no activity. Remove stale label or comment or this will be closed in 14 days."
           close-issue-message: "This issue was closed because it has been stalled for 35 days with no activity."

--- a/.github/workflows/super-linter.yaml
+++ b/.github/workflows/super-linter.yaml
@@ -23,7 +23,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Setup Python
-        uses: actions/setup-python@5.3.0
+        uses: actions/setup-python@v5.3.0
         with:
           python-version: "3.12"
       - name: Install dependencies


### PR DESCRIPTION
Hello from Product Security! 👋

We noticed that at least one of your Actions workflows is using one or more eligible immutable actions without semantic versioning. This PR will update the workflow to use the latest version of the action, using semantic versioning to opt into immutable actions.

### Why is this important?

Using an immutable action without indicating proper semantic version will result in the version being resolved to a tag that is mutable. This means the action code can between runs and without your knowledge.

Using an immutable action with proper semantic versioning will resolve to the **exact** version of the action stored in the GitHub package registry. The action code will not change between runs. This is a key security control to ensure the code you are running is the code you expect.

Thanks and happy coding! 🎉
