### PR TITLE
fix: continue on no update for repository

### DIFF
--- a/evergreen.py
+++ b/evergreen.py
@@ -172,9 +172,9 @@ def main():  # pragma: no cover
         if dependabot_file is None:
             print("\tNo (new) compatible package manager found")
             continue
-        else:
-            dependabot_file = yaml.dump(dependabot_file, stream)
-            dependabot_file = stream.getvalue()
+
+        yaml.dump(dependabot_file, stream)
+        dependabot_file = stream.getvalue()
 
         # If dry_run is set, just print the dependabot file
         if dry_run:

--- a/evergreen.py
+++ b/evergreen.py
@@ -171,6 +171,7 @@ def main():  # pragma: no cover
 
         if dependabot_file is None:
             print("\tNo (new) compatible package manager found")
+            continue
         else:
             dependabot_file = yaml.dump(dependabot_file, stream)
             dependabot_file = stream.getvalue()


### PR DESCRIPTION
# Pull Request

## Proposed Changes

In #265 a bug was introduced by removing the continue statement which prevents further processing of issue/pr creation for repositories where no update to the dependabot file was found. This PR just adds the continue statement again. Bug was confirmed by @ricardojdsilva87 already in comment of #265 and a fix is also part of #270.

Right now all evergreen runs fail with an error as soon as the first repository without changes is processed.

## Readiness Checklist

### Author/Contributor

- [x] If documentation is needed for this change, has that been included in this pull request
- [x] run `make lint` and fix any issues that you have introduced
- [x] run `make test` and ensure you have test coverage for the lines you are introducing
- [ ] If publishing new data to the public (scorecards, security scan results, code quality results, live dashboards, etc.), please request review from `@jeffrey-luszcz`

### Reviewer

- [ ] Label as either `fix`, `documentation`, `enhancement`, `infrastructure`, `maintenance` or `breaking`
