### PR TITLE
fix: harden pip install against supply chain attacks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ LABEL org.opencontainers.image.source https://github.com/github-community-projec
 WORKDIR /action/workspace
 COPY requirements.txt *.py /action/workspace/
 
-RUN python3 -m pip install --no-cache-dir -r requirements.txt \
+RUN python3 -m pip install --no-cache-dir --no-deps -r requirements.txt \
     && apt-get -y update \
     && apt-get -y install --no-install-recommends git=1:2.47.3-0+deb13u1 \
     && rm -rf /var/lib/apt/lists/*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,32 @@
-github3.py==4.0.1
-requests==2.32.5
+certifi==2026.2.25
+    # via requests
+cffi==2.0.0
+    # via cryptography
+charset-normalizer==3.4.4
+    # via requests
+cryptography==46.0.5
+    # via pyjwt
+github3-py==4.0.1
+    # via -r requirements.txt
+idna==3.11
+    # via requests
+pycparser==3.0
+    # via cffi
+pyjwt==2.11.0
+    # via github3-py
+python-dateutil==2.9.0.post0
+    # via github3-py
 python-dotenv==1.2.1
-ruamel.yaml==0.19.1
+    # via -r requirements.txt
+requests==2.32.5
+    # via
+    #   -r requirements.txt
+    #   github3-py
+ruamel-yaml==0.19.1
+    # via -r requirements.txt
+six==1.17.0
+    # via python-dateutil
+uritemplate==4.2.0
+    # via github3-py
+urllib3==2.6.3
+    # via requests


### PR DESCRIPTION
## Summary

Hardens the Docker build against supply chain attacks by preventing pip from resolving dependencies at install time.

Addresses the same class of vulnerability as [issue-metrics code scanning alert #94](https://github.com/github-community-projects/issue-metrics/security/code-scanning/94) — `pip install` without hash verification.

## Changes

### `requirements.txt`
- Expanded via `pip-compile` to pin all transitive dependencies to exact versions
- Ensures no implicit dependency resolution happens at install time

### `Dockerfile`
- Added `--no-deps` to `pip install`, preventing pip from resolving any packages beyond the explicit list

## Why this approach

The Opengrep rule recommends two mitigations:
1. `pip install --require-hashes` with hashed requirements
2. `pip install --no-deps` when using a pip-compile workflow

We chose option 2 because `--require-hashes` generates platform-specific hashes that break Dependabot automated dependency update PRs. The `--no-deps` approach with fully-resolved transitive dependencies provides equivalent security — no unvetted code can be introduced at install time.

## Testing

- Verified clean install with `--no-deps` in a fresh venv — all imports succeed