### PR TITLE
fix: add --project flag to uv entrypoint for GitHub Actions compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ HEALTHCHECK --interval=30s --timeout=10s --start-period=10s --retries=3 \
 
 ENV PYTHONUNBUFFERED=1
 CMD ["/action/workspace/evergreen.py"]
-ENTRYPOINT ["uv", "run"]
+ENTRYPOINT ["uv", "run", "--project", "/action/workspace"]


### PR DESCRIPTION
## Problem

The uv migration introduced a runtime regression in the Docker image. GitHub Actions' Docker container runner overrides the working directory to `/github/workspace` via `--workdir`, which causes `uv run` to not find the `pyproject.toml` at `/action/workspace`. It falls back to system Python (which has no packages installed), resulting in:

```
ModuleNotFoundError: No module named 'github3'
```

## Fix

Add `--project /action/workspace` to the `ENTRYPOINT` so `uv` always discovers the project and its `.venv` regardless of the runtime working directory.

## Testing

Verified locally with Docker:

| Test | Outcome |
|------|---------|
| **Before fix** (`--workdir /github/workspace`) | `ModuleNotFoundError: No module named 'github3'` ❌ |
| **After fix** (`--project /action/workspace`) | Imports succeed, runs correctly ✅ |