### PR TITLE
fix: move workflow permissions from job level to workflow level

### DIFF
--- a/.github/workflows/auto-labeler.yml
+++ b/.github/workflows/auto-labeler.yml
@@ -6,11 +6,9 @@ on:
     types: [opened, reopened, edited, synchronize]
 permissions:
   contents: read
+  pull-requests: write
 jobs:
   main:
-    permissions:
-      contents: read
-      pull-requests: write
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/auto-labeler.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       config-name: release-drafter.yml

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,16 +21,14 @@ on:
     - cron: "0 0 * * 1"
 
 permissions:
+  actions: read
   contents: read
+  security-events: write
 
 jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
-    permissions:
-      actions: read
-      contents: read
-      security-events: write
 
     strategy:
       fail-fast: false

--- a/.github/workflows/mark-ready-when-ready.yml
+++ b/.github/workflows/mark-ready-when-ready.yml
@@ -5,7 +5,10 @@ on:
     types: [opened, edited, labeled, unlabeled, synchronize]
 
 permissions:
-  contents: read
+  checks: read
+  contents: write
+  pull-requests: write
+  statuses: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
@@ -15,11 +18,6 @@ jobs:
   mark-ready:
     name: Mark as ready after successful checks
     runs-on: ubuntu-latest
-    permissions:
-      checks: read
-      contents: write
-      pull-requests: write
-      statuses: read
     if: |
       contains(github.event.pull_request.labels.*.name, 'Mark Ready When Ready') &&
       github.event.pull_request.draft == true

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -6,12 +6,10 @@ on:
     types: [opened, reopened, edited, synchronize]
 permissions:
   contents: read
+  pull-requests: read
+  statuses: write
 jobs:
   main:
-    permissions:
-      contents: read
-      pull-requests: read
-      statuses: write
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/pr-title.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     secrets:
       github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,12 +6,14 @@ on:
     types: [closed]
     branches: [main]
 permissions:
-  contents: read
+  attestations: write
+  contents: write
+  discussions: write
+  id-token: write
+  packages: write
+  pull-requests: read
 jobs:
   release:
-    permissions:
-      contents: write
-      pull-requests: read
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       publish: true
@@ -20,11 +22,6 @@ jobs:
       github-token: ${{ secrets.GITHUB_TOKEN }}
   release_image:
     needs: release
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
-      attestations: write
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-image.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       image-name: ${{ github.repository }}
@@ -37,9 +34,6 @@ jobs:
       image-registry-password: ${{ secrets.GITHUB_TOKEN }}
   release_discussion:
     needs: release
-    permissions:
-      contents: read
-      discussions: write
     uses: github-community-projects/ospo-reusable-workflows/.github/workflows/release-discussion.yaml@3b691dff6b68489c8548e1295d125c93c9c29a4e
     with:
       full-tag: ${{ needs.release.outputs.full-tag }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -15,15 +15,13 @@ on:
 
 permissions:
   contents: read
+  id-token: write
+  security-events: write
 
 jobs:
   analysis:
     name: Merge to Main Scorecard analysis
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      security-events: write
-      id-token: write
 
     steps:
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## What

Moves permissions declarations from job level back to workflow level across all workflow files.

## Why

Workflow-level `permissions` sets the maximum token permissions for all jobs. With `contents: read` at workflow level, job-level `contents: write` was silently capped, causing `Resource not accessible by integration` errors (e.g., `markPullRequestReadyForReview` in mark-ready-when-ready).

## Notes

- Multi-job workflows (e.g., release.yml) now declare the union of all job permissions at workflow level, which is slightly broader per-job but avoids the cap issue
- Reviewers should verify that no workflow previously had intentionally restricted job-level permissions that differ from other jobs in the same workflow